### PR TITLE
ner analyzer changes , tokenizer initialization updated .

### DIFF
--- a/obsei/analyzer/base_analyzer.py
+++ b/obsei/analyzer/base_analyzer.py
@@ -10,7 +10,6 @@ from obsei.workflow.base_store import BaseStore
 
 class BaseAnalyzerConfig(BaseModel):
     TYPE: str = "Base"
-    batch_size: int = 64
 
     class Config:
         arbitrary_types_allowed = True

--- a/obsei/analyzer/base_analyzer.py
+++ b/obsei/analyzer/base_analyzer.py
@@ -21,6 +21,7 @@ class BaseAnalyzer(BaseModel):
     TYPE: str = "Base"
     store: Optional[BaseStore] = None
     device: str = "auto"
+    batch_size: int = 64
 
     """
         auto: choose gpu if present else use cpu
@@ -31,13 +32,14 @@ class BaseAnalyzer(BaseModel):
     def __init__(self, **data: Any):
         super().__init__(**data)
         self._device_id = gpu_util.get_device_id(self.device)
+        self.batch_size = 4 if self._device_id == 0 else self.batch_size
 
     @abstractmethod
     def analyze_input(
         self,
         source_response_list: List[TextPayload],
         analyzer_config: Optional[BaseAnalyzerConfig] = None,
-        **kwargs
+        **kwargs,
     ) -> List[TextPayload]:
         pass
 

--- a/obsei/analyzer/classification_analyzer.py
+++ b/obsei/analyzer/classification_analyzer.py
@@ -65,7 +65,7 @@ class ZeroShotClassificationAnalyzer(BaseAnalyzer):
         self,
         source_response_list: List[TextPayload],
         analyzer_config: Optional[ClassificationAnalyzerConfig] = None,
-        **kwargs
+        **kwargs,
     ) -> List[TextPayload]:
         if analyzer_config is None:
             raise ValueError("analyzer_config can't be None")
@@ -88,7 +88,7 @@ class ZeroShotClassificationAnalyzer(BaseAnalyzer):
                 labels.append("negative")
 
         for batch_texts, batch_source_response in self._batchify(
-            texts, analyzer_config.batch_size, source_response_list
+            texts, self.batch_size, source_response_list
         ):
             batch_predictions = self._classify_text_from_model(
                 batch_texts,

--- a/obsei/analyzer/dummy_analyzer.py
+++ b/obsei/analyzer/dummy_analyzer.py
@@ -20,7 +20,7 @@ class DummyAnalyzer(BaseAnalyzer):
         self,
         source_response_list: List[TextPayload],
         analyzer_config: Optional[DummyAnalyzerConfig] = None,
-        **kwargs
+        **kwargs,
     ) -> List[TextPayload]:
         responses = []
         for source_response in source_response_list:

--- a/obsei/analyzer/ner_analyzer.py
+++ b/obsei/analyzer/ner_analyzer.py
@@ -25,15 +25,15 @@ class NERAnalyzer(BaseAnalyzer):
     model_name_or_path: str
     tokenizer_name: Optional[str] = None
     grouped_entities: Optional[bool] = True
-    ner_config : BaseAnalyzerConfig = BaseAnalyzerConfig(batch_size=1)
 
     def __init__(self, **data: Any):
         super().__init__(**data)
 
         model = AutoModelForTokenClassification.from_pretrained(self.model_name_or_path)
-        tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_name if self.tokenizer_name else self.model_name_or_path
-                                                  , use_fast=True)
-
+        tokenizer = AutoTokenizer.from_pretrained(
+            self.tokenizer_name if self.tokenizer_name else self.model_name_or_path,
+            use_fast=True,
+        )
 
         self._pipeline = pipeline(
             "ner",
@@ -73,12 +73,8 @@ class NERAnalyzer(BaseAnalyzer):
     def analyze_input(
         self,
         source_response_list: List[TextPayload],
-        analyzer_config: Optional[BaseAnalyzerConfig] = None,
-        **kwargs
+        **kwargs,
     ) -> List[TextPayload]:
-        if analyzer_config is not None:
-            self.ner_config = analyzer_config
-
         analyzer_output: List[TextPayload] = []
         texts = [
             source_response.processed_text[: self._max_length]
@@ -88,7 +84,7 @@ class NERAnalyzer(BaseAnalyzer):
         ]
 
         for batch_texts, batch_source_response in self._batchify(
-            texts, self.ner_config.batch_size, source_response_list
+            texts, self.batch_size, source_response_list
         ):
             batch_ner_predictions = self._classify_text_from_model(batch_texts)
             for ner_prediction, source_response in zip(

--- a/obsei/analyzer/ner_analyzer.py
+++ b/obsei/analyzer/ner_analyzer.py
@@ -35,7 +35,9 @@ class NERAnalyzer(BaseAnalyzer):
                 self.tokenizer_name, use_fast=True
             )
         else:
-            tokenizer = None
+            tokenizer = tokenizer = AutoTokenizer.from_pretrained(
+                self.model_name_or_path, use_fast=True
+            )
 
         self._pipeline = pipeline(
             "ner",
@@ -78,8 +80,9 @@ class NERAnalyzer(BaseAnalyzer):
         analyzer_config: Optional[BaseAnalyzerConfig] = None,
         **kwargs
     ) -> List[TextPayload]:
-        if analyzer_config is None:
-            raise ValueError("analyzer_config can't be None")
+        # if analyzer_config is None:
+        #     raise ValueError("analyzer_config can't be None")
+        ner_batch_size = 1
 
         analyzer_output: List[TextPayload] = []
         texts = [
@@ -90,7 +93,7 @@ class NERAnalyzer(BaseAnalyzer):
         ]
 
         for batch_texts, batch_source_response in self._batchify(
-            texts, analyzer_config.batch_size, source_response_list
+            texts, ner_batch_size, source_response_list
         ):
             batch_ner_predictions = self._classify_text_from_model(batch_texts)
             for ner_prediction, source_response in zip(

--- a/obsei/analyzer/ner_analyzer.py
+++ b/obsei/analyzer/ner_analyzer.py
@@ -25,19 +25,15 @@ class NERAnalyzer(BaseAnalyzer):
     model_name_or_path: str
     tokenizer_name: Optional[str] = None
     grouped_entities: Optional[bool] = True
+    ner_config : BaseAnalyzerConfig = BaseAnalyzerConfig(batch_size=1)
 
     def __init__(self, **data: Any):
         super().__init__(**data)
 
         model = AutoModelForTokenClassification.from_pretrained(self.model_name_or_path)
-        if self.tokenizer_name:
-            tokenizer = AutoTokenizer.from_pretrained(
-                self.tokenizer_name, use_fast=True
-            )
-        else:
-            tokenizer = tokenizer = AutoTokenizer.from_pretrained(
-                self.model_name_or_path, use_fast=True
-            )
+        tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_name if self.tokenizer_name else self.model_name_or_path
+                                                  , use_fast=True)
+
 
         self._pipeline = pipeline(
             "ner",
@@ -80,9 +76,8 @@ class NERAnalyzer(BaseAnalyzer):
         analyzer_config: Optional[BaseAnalyzerConfig] = None,
         **kwargs
     ) -> List[TextPayload]:
-        # if analyzer_config is None:
-        #     raise ValueError("analyzer_config can't be None")
-        ner_batch_size = 1
+        if analyzer_config is not None:
+            self.ner_config = analyzer_config
 
         analyzer_output: List[TextPayload] = []
         texts = [
@@ -93,7 +88,7 @@ class NERAnalyzer(BaseAnalyzer):
         ]
 
         for batch_texts, batch_source_response in self._batchify(
-            texts, ner_batch_size, source_response_list
+            texts, self.ner_config.batch_size, source_response_list
         ):
             batch_ner_predictions = self._classify_text_from_model(batch_texts)
             for ner_prediction, source_response in zip(

--- a/obsei/analyzer/ner_analyzer.py
+++ b/obsei/analyzer/ner_analyzer.py
@@ -73,6 +73,7 @@ class NERAnalyzer(BaseAnalyzer):
     def analyze_input(
         self,
         source_response_list: List[TextPayload],
+        analyzer_config: Optional[BaseAnalyzerConfig] = None,
         **kwargs,
     ) -> List[TextPayload]:
         analyzer_output: List[TextPayload] = []

--- a/obsei/analyzer/sentiment_analyzer.py
+++ b/obsei/analyzer/sentiment_analyzer.py
@@ -33,7 +33,7 @@ class VaderSentimentAnalyzer(BaseAnalyzer):
         self,
         source_response_list: List[TextPayload],
         analyzer_config: BaseAnalyzerConfig = None,
-        **kwargs
+        **kwargs,
     ) -> List[TextPayload]:
         analyzer_output: List[TextPayload] = []
 
@@ -72,11 +72,11 @@ class TransformersSentimentAnalyzer(ZeroShotClassificationAnalyzer):
         self,
         source_response_list: List[TextPayload],
         analyzer_config: Optional[TransformersSentimentAnalyzerConfig] = None,
-        **kwargs
+        **kwargs,
     ) -> List[TextPayload]:
         return super().analyze_input(
             source_response_list=source_response_list,
             analyzer_config=analyzer_config,
             add_positive_negative_labels=True,
-            **kwargs
+            **kwargs,
         )

--- a/obsei/analyzer/translation_analyzer.py
+++ b/obsei/analyzer/translation_analyzer.py
@@ -47,8 +47,7 @@ class TranslationAnalyzer(BaseAnalyzer):
         analyzer_config: Optional[BaseAnalyzerConfig] = None,
         **kwargs,
     ) -> List[TextPayload]:
-        if analyzer_config is None:
-            raise ValueError("analyzer_config can't be None")
+
         analyzer_output = []
         texts = [
             source_response.processed_text[: self._max_length]
@@ -58,7 +57,7 @@ class TranslationAnalyzer(BaseAnalyzer):
         ]
 
         for batch_texts, batch_source_response in self._batchify(
-            texts, analyzer_config.batch_size, source_response_list
+            texts, self.batch_size, source_response_list
         ):
             batch_predictions = self._pipeline(batch_texts)
 

--- a/obsei/analyzer/translation_analyzer.py
+++ b/obsei/analyzer/translation_analyzer.py
@@ -45,7 +45,7 @@ class TranslationAnalyzer(BaseAnalyzer):
         self,
         source_response_list: List[TextPayload],
         analyzer_config: Optional[BaseAnalyzerConfig] = None,
-        **kwargs
+        **kwargs,
     ) -> List[TextPayload]:
         if analyzer_config is None:
             raise ValueError("analyzer_config can't be None")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -34,7 +34,9 @@ def ner_analyzer():
 
 @pytest.fixture(scope="session")
 def translate_analyzer():
-    return TranslationAnalyzer(model_name_or_path="Helsinki-NLP/opus-mt-hi-en")
+    return TranslationAnalyzer(
+        model_name_or_path="Helsinki-NLP/opus-mt-hi-en", batch_size=1
+    )
 
 
 @pytest.fixture(scope="session")

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -57,7 +57,6 @@ def test_ner_analyzer(ner_analyzer):
     ]
     analyzer_responses = ner_analyzer.analyze_input(
         source_response_list=source_responses,
-        analyzer_config=BaseAnalyzerConfig(batch_size=1),
     )
     assert len(analyzer_responses) == 1
 

--- a/test/test_analyzer.py
+++ b/test/test_analyzer.py
@@ -51,7 +51,7 @@ def test_vader_analyzer(vader_analyzer):
 def test_ner_analyzer(ner_analyzer):
     source_responses = [
         TextPayload(
-            processed_text="My name is Lalit and I live in Berlin, Germany.",
+            processed_text="My name is Sam and I live in Berlin, Germany.",
             source_name="sample",
         )
     ]
@@ -63,7 +63,7 @@ def test_ner_analyzer(ner_analyzer):
     entities = analyzer_responses[0].segmented_data["data"]
     matched_count = 0
     for entity in entities:
-        if entity["word"] == "Lalit" and entity["entity_group"] == "PER":
+        if entity["word"] == "Sam" and entity["entity_group"] == "PER":
             matched_count = matched_count + 1
         elif entity["word"] == "Berlin" and entity["entity_group"] == "LOC":
             matched_count = matched_count + 1

--- a/test/test_translator.py
+++ b/test/test_translator.py
@@ -20,7 +20,6 @@ def test_translate_analyzer(translate_analyzer):
     ]
     analyzer_responses = translate_analyzer.analyze_input(
         source_response_list=source_responses,
-        analyzer_config=BaseAnalyzerConfig(batch_size=1),
     )
     assert len(analyzer_responses) == len(TEXTS)
 


### PR DESCRIPTION
Apart from the tokenizer fix , I also observed one more thing, in the documentation of configure Ner Analyzer it is mentioned that  _"# NER analyzer does not need configuration settings" ._ 
But while predicting the NER tags using NERAnalyzer's **analyze_input** method, analyzer_config is required (below). Hence the NER tagging fails. 

```
        if analyzer_config is None:
             raise ValueError("analyzer_config can't be None")
``` 

So two things can be done, either we mention config setting for analyzer 
or fix the batch size 1 in code,
I have done a quick fix here but I need your comment so I can make a cleaner fix. Either make the ner's **analyze_input** batch free or define a config and a batch size for ners . 